### PR TITLE
Allow 'confirm' and 'cancel' buttons to grow

### DIFF
--- a/app/css/market.css
+++ b/app/css/market.css
@@ -64,7 +64,7 @@ span.cell {
 
 .market-table button.btn-xs {
 	display: table-cell;
-	width: 5em;
+	min-width: 5em;
 }
 
 .market-table button.btn-xs {


### PR DESCRIPTION
Depending on the used locale, the text that is to be displayed might need more than the default space. Fixes #415
