### PR TITLE
fix for slow typeahead when searching through markets

### DIFF
--- a/app/templates/market/markets.html
+++ b/app/templates/market/markets.html
@@ -48,7 +48,7 @@
           <!--<li ng-repeat="m in markets track by $index"><a ng-click="select_market(m)">{{m}}</a></li>--><!--</ul>-->
           <input type="text"
                  ng-model="selected_market"
-                 typeahead="value for value in markets | filter:$viewValue"
+                 typeahead="value for value in markets | filter:$viewValue | limitTo:10"
                  typeahead-editable="false"
                  typeahead-append-to-body="true"
                  class="form-control"


### PR DESCRIPTION
This fixes #488

It was due to the markets containing 5750 possible combinations, most of them containing "BIT", so displaying a list of hundreds of items on a search was really slow.
