### PR TITLE
Exclude "scam" assets, flatten orderbook chart, add some columns to delegates table

### DIFF
--- a/app/css/market.css
+++ b/app/css/market.css
@@ -208,6 +208,10 @@ tr.short_wall td {
 	height: 240px;
 }
 
+.advanced-mode {
+	padding-bottom: 1em;
+}
+
 .tab-short {
 	display: none !important;
 }

--- a/app/js/controllers/account.coffee
+++ b/app/js/controllers/account.coffee
@@ -1,7 +1,7 @@
-angular.module("app").controller "AccountController", ($scope, $state, $filter, $location, $stateParams, $q, Growl, Wallet, Utils, WalletAPI, $modal, Blockchain, BlockchainAPI, Info, Observer, $translate) ->
+angular.module("app").controller "AccountController", ($scope, $state, $filter, $location, $stateParams, $window, $q, Growl, Wallet, Utils, WalletAPI, $modal, Blockchain, BlockchainAPI, Info, Observer, $translate) ->
 
     Info.refresh_info()
-    $scope.refresh_addresses=Wallet.refresh_accounts
+    $scope.refresh_addresses = Wallet.refresh_accounts
     name = $stateParams.name
     $scope.account_name = name
     $scope.utils = Utils
@@ -41,7 +41,7 @@ angular.module("app").controller "AccountController", ($scope, $state, $filter, 
     $scope.p = { pendingRegistration: Wallet.pendingRegistrations[name] }
     $scope.wallet_info = {file: "", password: "", type: 'Bitcoin/PTS'}
     Blockchain.refresh_delegates().then ->
-        if ($scope.account && $scope.account.delegate_info)
+        if ($scope.account and $scope.account.delegate_info)
             $scope.active_delegate = Blockchain.delegate_active_hash_map[name]
             $scope.rank = Blockchain.all_delegates[name].rank
     # TODO: mixing the wallet account with blockchain account is not a good thing.
@@ -56,12 +56,12 @@ angular.module("app").controller "AccountController", ($scope, $state, $filter, 
                 WalletAPI.account_update_private_data(name, $scope.account.private_data)
         )
         $scope.account_name = acct.name
-        if (acct.gui_data && acct.gui_data.website)
+        if (acct.gui_data and acct.gui_data.website)
             $scope.website = acct.gui_data.website;
-        if (acct.public_data && acct.public_data.website)
+        if (acct.public_data and acct.public_data.website)
             $scope.website = acct.public_data.website;
         
-        if $scope.website.indexOf('http://') == -1 && $scope.website.indexOf('https://') == -1
+        if $scope.website and $scope.website.indexOf('http://') == -1 and $scope.website.indexOf('https://') == -1
             $scope.website = 'http://' + $scope.website
 
         Wallet.set_current_account(acct) if acct.is_my_account
@@ -208,3 +208,7 @@ angular.module("app").controller "AccountController", ($scope, $state, $filter, 
             scope: $scope
         #else
         #  Growl.error '','Account registration requires funds.  Please fund one of your accounts.'
+
+    $scope.link = (address) ->
+        $window.open(address)
+        return true

--- a/app/js/controllers/delegates.coffee
+++ b/app/js/controllers/delegates.coffee
@@ -10,6 +10,10 @@ angular.module("app").controller "DelegatesController", ($scope, $location, $sta
     $scope.p.numberOfPages = Math.ceil($scope.inactive_delegates.length / $scope.p.pageSize)
     $scope.accounts = Wallet.accounts
 
+    $scope.orderByField = "rank";
+    $scope.reverseSort = false;
+    $scope.orderByFieldStandby = "rank";
+    $scope.reverseSortStandby = false;
 
     $q.all([Wallet.refresh_accounts(), Blockchain.refresh_delegates()]).then ->
         $scope.active_delegates = Blockchain.active_delegates

--- a/app/js/controllers/delegates.coffee
+++ b/app/js/controllers/delegates.coffee
@@ -1,4 +1,4 @@
-angular.module("app").controller "DelegatesController", ($scope, $location, $state, $q, Growl, Blockchain, Wallet, RpcService, Info) ->
+angular.module("app").controller "DelegatesController", ($scope, $location, $state, $window, $q, Growl, Blockchain, Wallet, RpcService, Info) ->
     $scope.active_delegates = Blockchain.active_delegates
     $scope.inactive_delegates = Blockchain.inactive_delegates
     $scope.avg_act_del_pay_rate = Blockchain.avg_act_del_pay_rate
@@ -49,3 +49,9 @@ angular.module("app").controller "DelegatesController", ($scope, $location, $sta
             if (value.delegate_info && value.approved!=0)
                 Wallet.approve_account(key, 0).then ->
                     Wallet.accounts[key].approved=0
+
+    $scope.link = (address) ->
+        if address.indexOf('http://') == -1 and address.indexOf('https://') == -1
+            address = 'http://' + address
+        $window.open(address)
+        return true

--- a/app/js/controllers/markets.coffee
+++ b/app/js/controllers/markets.coffee
@@ -55,6 +55,12 @@ angular.module("app").controller "MarketsController", ($scope, $state, Wallet, B
 
     Blockchain.refresh_asset_records().then (records) ->
         $scope.markets = Blockchain.get_markets()
+        # for market, index in $scope.markets by -1
+           # console.log('index:',index, 'market:',market);
+            # for market2 in $scope.markets
+                # if market2.issuer_account_id == -2 && market.symbol.toLowercase() == market2.symbol.toLowerCase()
+                    # console.log('user asset:',market.symbol,'market asset:',market2.symbol)
+
         main_asset = Blockchain.asset_records[0]
         $scope.featured_markets.push "BitUSD:#{main_asset.symbol}"
         $scope.featured_markets.push "BitCNY:#{main_asset.symbol}"
@@ -68,7 +74,12 @@ angular.module("app").controller "MarketsController", ($scope, $state, Wallet, B
             asset.c_fees = Utils.newAsset(asset.collected_fees, asset.symbol, asset.precision)
             assets_with_unknown_issuer.push asset unless asset.account_name
             if asset.issuer_account_id > 0
-                $scope.user_issued_assets.push asset
+                scam = false;
+                for key2, asset2 of records
+                    if (asset2.issuer_account_id == -2 and ("bit"+asset2.symbol).toLowerCase() == asset.symbol.toLowerCase())
+                        scam = true
+                if not scam
+                    $scope.user_issued_assets.push asset
             else if asset.issuer_account_id == -2
                 $scope.market_peg_assets.push asset
         if assets_with_unknown_issuer.length > 0

--- a/app/js/directives/misc.coffee
+++ b/app/js/directives/misc.coffee
@@ -107,3 +107,11 @@ angular.module("app.directives").directive "focus", ($timeout) ->
     link: (scope, element) ->
         $timeout -> element[0].focus()
 
+angular.module("app.directives").directive "ngSortFa", () ->
+    restrict: 'E',
+    scope: 
+      'orderString':'@',
+      'orderByField':'@',
+      'reverseSort':'@'
+    templateUrl: 'ng-sort-template.html'
+

--- a/app/js/services/blockchain.coffee
+++ b/app/js/services/blockchain.coffee
@@ -129,7 +129,7 @@ class Blockchain
                             markets_hash[value] = value
         angular.forEach markets_hash, (key, value) ->
             markets.push value
-        console.log markets.length
+        # console.log markets
         markets
 
 

--- a/app/js/services/blockchain.coffee
+++ b/app/js/services/blockchain.coffee
@@ -110,16 +110,26 @@ class Blockchain
             angular.forEach @asset_records, (asset2) =>
                 if not (asset1.id > 22 and asset2.id > 22) # one of the assets should be either bts or market pegged asset
                     asset1_symbol = if asset1.issuer_account_id == -2 then "Bit" + asset1.symbol else asset1.symbol
-                    asset2_symbol = if asset2.issuer_account_id == -2 then "Bit" + asset2.symbol else asset2.symbol
+                    asset2_symbol = if asset2.issuer_account_id == -2 then "Bit" + asset2.symbol else asset2.symbol                    
                     if asset1.id > asset2.id
-                        value = asset1_symbol + ":" + asset2_symbol
-                        markets_hash[value] = value
+                        scam = false
+                        angular.forEach @asset_records, (asset3) =>
+                            if (asset3.issuer_account_id == -2 and ("bit"+asset3.symbol).toLowerCase() == asset1.symbol.toLowerCase())
+                                scam = true
+                        if not scam
+                            value = asset1_symbol + ":" + asset2_symbol
+                            markets_hash[value] = value
                     else if asset2.id > asset1.id
-                        value = asset2_symbol + ":" + asset1_symbol
-                        markets_hash[value] = value
+                        scam = false
+                        angular.forEach @asset_records, (asset3) =>
+                            if (asset3.issuer_account_id == -2 and ("bit"+asset3.symbol).toLowerCase() == asset2.symbol.toLowerCase())
+                                scam = true
+                         if not scam
+                            value = asset2_symbol + ":" + asset1_symbol
+                            markets_hash[value] = value
         angular.forEach markets_hash, (key, value) ->
             markets.push value
-        #console.log markets
+        console.log markets.length
         markets
 
 

--- a/app/js/services/market_helper.coffee
+++ b/app/js/services/market_helper.coffee
@@ -214,4 +214,34 @@ class MarketHelper
             return parseFloat str_value.replace(/,/g, "")
         return parseFloat value
 
+    flatten_orderbookchart: (array, sumBoolean, inverse, precision) ->
+        inverse = if inverse == undefined then false else inverse;
+        orderBookArray = [];
+        if inverse
+            array.sort (a, b) ->
+                a[0] - b[0]
+
+            if array and array.length
+                arrayLength = array.length - 1;
+                orderBookArray.unshift([array[arrayLength][0], array[arrayLength][1]])
+                for i in [array.length-2...0]
+                    maxStep = Math.min((array[i + 1][0] - array[i][0] ) / 2, 0.1 / precision)
+                    orderBookArray.unshift([array[i][0] + maxStep, array[i + 1][1]])
+                    if (sumBoolean) 
+                        array[i][1] += array[i - 1][1]                        
+                    orderBookArray.unshift([array[i][0], array[i][1]])
+
+        else 
+            if array and array.length
+                orderBookArray.push([array[0][0], array[0][1]])
+
+                for i in [1...array.length]
+                    maxStep = Math.min((array[i][0] - array[i - 1][0]) / 2, 0.1 / precision)
+                    orderBookArray.push([array[i][0] - maxStep, array[i - 1][1]])
+                    if (sumBoolean) 
+                        array[i][1] += array[i - 1][1]                        
+                    orderBookArray.push([array[i][0], array[i][1]])                    
+
+        orderBookArray
+
 angular.module("app").service("MarketHelper", ["$filter", "Utils",  MarketHelper])

--- a/app/js/services/market_service.coffee
+++ b/app/js/services/market_service.coffee
@@ -551,7 +551,6 @@ class MarketService
                 market.price_history = ohlc_data
                 market.volume_history = volume_data
 
-
     pull_market_data: (data, deferred) ->
         self = data.context
         self.loading_promise = deferred.promise
@@ -570,7 +569,7 @@ class MarketService
             promises.push(self.pull_shorts(market, self.market.inverted))
             promises.push(self.pull_covers(market, self.market.inverted))
 
-        promises.push(self.pull_price_history(market, self.market.inverted)) if @counter % 5 == 0
+        promises.push(self.pull_price_history(market, self.market.inverted)) if @counter % 5 == 0       
 
         self.q.all(promises).finally =>
             try
@@ -599,9 +598,10 @@ class MarketService
                     self.helper.add_to_order_book_chart_array(bids_array, b.price, sum_bids)
                 bids_array.sort (a,b) -> a[0] - b[0]
                 asks_array.sort (a,b) -> a[0] - b[0]
+                
                 self.market.orderbook_chart_data =
-                    bids_array: bids_array
-                    asks_array: asks_array
+                    bids_array: self.helper.flatten_orderbookchart(bids_array,false,true, self.market.price_precision)
+                    asks_array: self.helper.flatten_orderbookchart(asks_array,false,false, self.market.price_precision)
 
                 # shorts collateralization chart data
                 self.helper.sort_array(self.shorts, "price", "quantity", self.market.inverted)

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -42,7 +42,7 @@
           <i class="fa fa-fw fa-check text-success"></i> <span tooltip=" {{ 'account.reg_date' | translate }}: {{ account.registration_date | prettyDate }}" translate>directory.registered</span>
           &nbsp; 
           <br/>
-          <a style="color:white;" target="_blank" href='{{ website }}'>{{ website }}</a>
+          <a style="color:white;" ng-click="link(website)">{{ website }}</a>
           <div ng-if="delegate.role" style='color:white;font-size:150%'>Role: {{ delegate.role }}</div>
         </div>
       </div>

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -1,7 +1,7 @@
 <div class="account-page" ng-class="(account.delegate_info) ? 'row head-bg-delegate p-inner' : 'row head-bg p-inner'">
   <div class="col-sm-2">
     <div class="avatar-150">
-      <img ng-src="http://robohash.org/set_1/{{account_name}}?size=150x150" height="150" width="150"/>
+      <img ng-src="http://robohash.org/set_1/{{account_name}}?size=200x200" height="150" width="150"/>
     </div>
     <br/>
     <div class="text-center avatar-150">

--- a/app/templates/account_balances.html
+++ b/app/templates/account_balances.html
@@ -14,7 +14,7 @@
         <tbody>
         <tr ng-click="go_to_account(a.name)" ng-repeat="a in accounts" ng-show='a.is_my_account'>
                 <td class="avatar-40">
-                  <img ng-src="http://robohash.org/set_1/{{a.name}}?size=40x40" height="40" width="40"/>
+                  <img ng-src="http://robohash.org/set_1/{{a.name}}?size=200x200" height="40" width="40"/>
               </td>
               <td>         
                  <b>{{a.name}}</b>

--- a/app/templates/account_delegate.html
+++ b/app/templates/account_delegate.html
@@ -1,5 +1,5 @@
 <h5 ng-if="account.public_data.delegate.description"><span translate>delegate.description</span> :<span style="font-weight:bold;"> {{ account.public_data.delegate.description }}</span></h5>
-<h5 ng-if="account.public_data.delegate.proposal"><span translate>delegate.proposal</span> : <a href='{{ account.public_data.delegate.proposal }}' target="_blank"><span style="font-weight:bold;">{{ account.public_data.delegate.proposal }}</span></a></h5>
+<h5 ng-if="account.public_data.delegate.proposal"><span translate>delegate.proposal</span> : <a ng-click="link(account.public_data.delegate.proposal)"><span style="font-weight:bold;">{{ account.public_data.delegate.proposal }}</span></a></h5>
 <h5 ng-if="account.public_data.delegate.country"><span translate>delegate.country</span> : <span style="font-weight:bold;">{{ account.public_data.delegate.country }}</span></h5>
 <h5 ng-if="account.public_data.delegate.location"><span translate>delegate.location</span> : <span style="font-weight:bold;">{{ account.public_data.delegate.location }}</span></h5>
 <h5 ng-if="account.public_data.delegate.handle"><span translate>delegate.handle</span> : <span style="font-weight:bold;">{{ account.public_data.delegate.handle }}</span></h5>

--- a/app/templates/account_transactions.html
+++ b/app/templates/account_transactions.html
@@ -44,13 +44,13 @@
               <div class="avatar-40">
                 <span ng-if="account.name==entry.from">
                     <img ng-if="entry.to[0] !== entry.to[0].toUpperCase()"
-                         ng-src="http://robohash.org/set_1/{{entry.to}}?size=80x80" height="40" width="40"/>
+                         ng-src="http://robohash.org/set_1/{{entry.to}}?size=200x200" height="40" width="40"/>
                     <img ng-if="account.name != entry.to && entry.to[0] === entry.to[0].toUpperCase()"
-                         ng-src="http://robohash.org/set_1/{{account.name}}?size=80x80" height="40" width="40"/>
+                         ng-src="http://robohash.org/set_1/{{account.name}}?size=200x200" height="40" width="40"/>
                 </span>
                 <span ng-if="account.name==entry.to && account.name!=entry.from">
                     <span ng-if="entry.from.charAt(0) !== 'X' && entry.from[0] !== entry.from[0].toUpperCase()">
-                        <img ng-src="http://robohash.org/set_1/{{entry.from}}?size=80x80" height="40" width="40"/>
+                        <img ng-src="http://robohash.org/set_1/{{entry.from}}?size=200x200" height="40" width="40"/>
                     </span>
                     <span ng-if="entry.from.charAt(0) === 'X'">
                         <img ng-src="img/user.png" height="40" width="40"/>

--- a/app/templates/addressbookmodal.html
+++ b/app/templates/addressbookmodal.html
@@ -13,7 +13,7 @@
 
         <ul class="list-group contacts-list">
           <li class="list-group-item" ng-repeat="name in favorites | filter:contact_name_filter">
-            <img ng-src="http://robohash.org/set_1/{{name}}?size=64x64" height="32" width="32"/>
+            <img ng-src="http://robohash.org/set_1/{{name}}?size=200x200" height="32" width="32"/>
             {{name}}
           </li>
         </ul>
@@ -32,7 +32,7 @@
     <div class="row">
       <div class="col-md-2">
         <div class="avatar">
-          <img ng-src="http://robohash.org/set_1/{{account.name}}?size=100x100" height="100" width="100" ng-if="account.name"/>
+          <img ng-src="http://robohash.org/set_1/{{account.name}}?size=200x200" height="100" width="100" ng-if="account.name"/>
           <img src="img/user.png" height="100" width="100" ng-if="!account.name"/>
         </div>
       </div>

--- a/app/templates/contacts.html
+++ b/app/templates/contacts.html
@@ -25,7 +25,7 @@
             <tr ng-repeat="c in contacts | filter:q">
               <td style='width:1%;white-space:nowrap'>
                   <div class="avatar-40">
-                    <img ng-src="http://robohash.org/set_1/{{c.name}}?size=40x40" height="40" width="40"/>
+                    <img ng-src="http://robohash.org/set_1/{{c.name}}?size=200x200" height="40" width="40"/>
                   </div>
               </td>
               <td style='width:1%;white-space:nowrap'>

--- a/app/templates/createaccount.html
+++ b/app/templates/createaccount.html
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col-sm-2">
       <div class="avatar">
-        <img ng-src="http://robohash.org/set_1/{{f.name}}?size=150x150" height="150" width="150" ng-if="f.name"
+        <img ng-src="http://robohash.org/set_1/{{f.name}}?size=200x200" height="150" width="150" ng-if="f.name"
              tooltip="Your RoboHash is a security feature that helps you verify account names visually"/> <img
           src="img/user.png" height="150" width="150" ng-if="!f.name"/>
       </div>

--- a/app/templates/delegates/delegates_list.html
+++ b/app/templates/delegates/delegates_list.html
@@ -3,16 +3,16 @@
     <span translate>delegate.un_approve_all</span>
   </button>
 </div>
-    <div class="col-sm-6">
-    <table style='width:100%' class="table table-hover">
+<div class="col-sm-6">
+  <table style='width:100%' class="table table-hover">
     <tr>
-    <td><b translate>delegate.max_pay_per_blk</b></td> <td><b>{{blockchain_delegate_pay_rate}}</b></td>
+      <td><b translate>delegate.max_pay_per_blk</b></td> <td><b>{{blockchain_delegate_pay_rate}}</b></td>
     </tr>
     <tr>
-    <td><b translate>delegate.avg_active_delegate_pay_rate</b> </td> <td> <b> {{avg_act_del_pay_rate | number:2}}</b> % </td>
+      <td><b translate>delegate.avg_active_delegate_pay_rate</b> </td> <td> <b> {{avg_act_del_pay_rate | number:2}}</b> % </td>
     </tr>
-    </table>
-    </div>
+  </table>
+</div>
 <div class="row">
   <div class="col-sm-3">
     <input type="text" class="form-control" ng-model="search.name" placeholder="{{'pagination.filter'|translate}}">
@@ -30,6 +30,7 @@
             <th translate>th.rank</th>
             <th translate>th.name</th>
             <th translate>th.approval</th>
+            <th translate>th.reliability</th>
             <th translate>th.pay_rate</th>
             <th translate>th.approve</th>
           </tr>
@@ -38,21 +39,89 @@
           <tr ng-repeat="del in active_delegates | filter:search">
             <td>{{ del.rank }}</td>
             <td>
-              <a class='delegate-link' ui-sref="account.delegate({name: del.name})">{{ del.name }}</a>
+              <a class='delegate-link' ui-sref="account.delegate({name: del.name})"><strong>{{ del.name }}</strong></a>
               <br>
               <i ng-show="del.public_data.version"> <span translate>delegate.version</span>: {{del.public_data.version}} </i>
               <br>
-              <i><a target="_blank" href='http://{{del.public_data.gui_data.website}}'> {{del.public_data.gui_data.website}} </a></i>
+              <!-- <i><a target="_blank" href='http://{{del.public_data.gui_data.website}}'> {{del.public_data.gui_data.website}} </a></i> -->
+              <i><a ng-click="link(del.public_data.website)">{{del.public_data.website}} </a></i>
             </td>
             <td>
+              <span ng-switch on='del.delegate_info.votes_for/current_xts_supply<0.0001'
+              tooltip="{{ 'delegate.votes_obtained' | translate }}: {{ del.delegate_info.votes_for | formatVotes}}">
+              <span ng-switch-when='true'>&#60;0.01%</span>
+              <span ng-switch-default>{{ (del.delegate_info.votes_for)/current_xts_supply*100 | number:2 }}%</span>
+            </span>
+          </td>
+          <td>
+            <span ng-show="del.delegate_info.blocks_produced>0">{{ del.delegate_info.blocks_produced/(del.delegate_info.blocks_produced + del.delegate_info.blocks_missed)*100 | number:2 }}%</span>
+          </td>
+          <td>{{ del.delegate_info.pay_rate }}%</td>
+          <!--<td style="max-width: 100px; font-size: 10px; text-overflow: ellipsis;">{{del.feeds.join(', ')}}</td>-->
+          <td>
+            <div class="btn-group">
+              <button ng-click="toggleVoteUp(del.name)" class="btn btn-sm btn-link primary" tooltip="{{ 'account.toggle.approval' | translate }}">
+                <i ng-if="accounts[del.name].approved>0" class='fa fa-thumbs-up fa-2x'></i>
+                <i ng-if="!accounts[del.name].approved || account.approved==0" class='fa fa-thumbs-o-up fa-2x'></i>
+                <i ng-if="accounts[del.name].approved<0" class='fa fa-thumbs-down fa-2x'></i>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</div>
+
+<div class="row">
+  <div class="col-lg-12">
+    <div>
+      <div class="header">
+        <h4 class="header-title" translate>delegate.standby_delegates</h4>
+      </div>
+      <div class="col-sm-12">
+        <ul class="pagination pagination-sm">
+          <li ><a class="btn" ng-disabled="p.currentPage == 0" ng-click="p.currentPage=0" translate>pagination.first</a></li>
+          <li><a class="btn" ng-disabled="p.currentPage == 0" ng-click="p.currentPage=p.currentPage-1" translate>pagination.prev</a></li>
+          <li> <span class="btn btn-primary" style="color: #FFF; font-size: 110%; font-weight: 100;padding: 4px 12px;">{{p.currentPage+1}}/{{p.numberOfPages}}</span></li>
+          <li><a class="btn" ng-disabled="p.currentPage >= p.numberOfPages - 1" ng-click="p.currentPage=p.currentPage+1" translate>pagination.next</a></li>
+          <li><a class="btn" ng-disabled="p.currentPage == p.numberOfPages - 1" ng-click="p.currentPage=p.numberOfPages - 1" translate>pagination.last</a></li>
+        </ul>
+      </div>
+      <div>
+        <table class="table table-striped">
+          <thead>
+            <tr style="text-transform: uppercase;">
+              <th translate>th.rank</th>
+              <th translate>th.name</th>
+              <th translate>th.approval</th>
+              <th translate>th.reliability</th>
+              <th translate>th.pay_rate</th>
+              <th translate>th.approve</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="del in inactive_delegates | filter:search | startFrom: p.currentPage * p.pageSize | limitTo : p.pageSize">
+              <td>{{ del.rank }}</td>
+              <td>
+                <a class='delegate-link' ui-sref="account.delegate({name: del.name})">{{ del.name }}</a>
+                <br>
+                <i ng-show="del.public_data.version"> Version: {{del.public_data.version}} </i>
+                <br>
+                <i><a ng-click="link(del.public_data.website)"> {{del.public_data.website}} </a></i>
+              </td>
+              <td>
                 <span ng-switch on='del.delegate_info.votes_for/current_xts_supply<0.0001'
-                      tooltip="{{ 'delegate.votes_obtained' | translate }}: {{ del.delegate_info.votes_for | formatVotes}}">
-                  <span ng-switch-when='true'>&#60;0.01%</span>
-                  <span ng-switch-default>{{ (del.delegate_info.votes_for)/current_xts_supply*100 | number:2 }}%</span>
-                </span>
+                tooltip="{{ 'delegate.votes_obtained' | translate }}: {{ del.delegate_info.votes_for | formatVotes}}">
+                <span ng-switch-when='true'>&#60;0.01%</span>
+                <span ng-switch-default>{{ (del.delegate_info.votes_for)/current_xts_supply*100 | number:2 }}%</span>
+              </span>
+            </td>
+            <td>
+              <span ng-show="del.delegate_info.blocks_produced > 0">{{ del.delegate_info.blocks_produced/(del.delegate_info.blocks_produced + del.delegate_info.blocks_missed)*100 | number:2 }}%</span>
             </td>
             <td>{{ del.delegate_info.pay_rate }}%</td>
-            <!--<td style="max-width: 100px; font-size: 10px; text-overflow: ellipsis;">{{del.feeds.join(', ')}}</td>-->
             <td>
               <div class="btn-group">
                 <button ng-click="toggleVoteUp(del.name)" class="btn btn-sm btn-link primary" tooltip="{{ 'account.toggle.approval' | translate }}">
@@ -68,64 +137,4 @@
     </div>
   </div>
 </div>
-
-<div class="row">
-  <div class="col-lg-12">
-    <div>
-      <div class="header">
-        <h4 class="header-title" translate>delegate.standby_delegates</h4>
-      </div>
-      <div class="col-sm-12">
-              <ul class="pagination pagination-sm">
-                    <li ><a class="btn" ng-disabled="p.currentPage == 0" ng-click="p.currentPage=0" translate>pagination.first</a></li>
-                    <li><a class="btn" ng-disabled="p.currentPage == 0" ng-click="p.currentPage=p.currentPage-1" translate>pagination.prev</a></li>
-                    <li> <span class="btn btn-primary" style="color: #FFF; font-size: 110%; font-weight: 100;padding: 4px 12px;">{{p.currentPage+1}}/{{p.numberOfPages}}</span></li>
-                    <li><a class="btn" ng-disabled="p.currentPage >= p.numberOfPages - 1" ng-click="p.currentPage=p.currentPage+1" translate>pagination.next</a></li>
-                    <li><a class="btn" ng-disabled="p.currentPage == p.numberOfPages - 1" ng-click="p.currentPage=p.numberOfPages - 1" translate>pagination.last</a></li>
-                </ul>
-              </div>
-      <div>
-        <table class="table table-striped">
-          <thead>
-            <tr style="text-transform: uppercase;">
-              <th translate>th.rank</th>
-              <th translate>th.name</th>
-              <th translate>th.approval</th>
-              <th class='hideableCol' translate>th.pay_rate</th>
-              <th translate>th.approve</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr ng-repeat="del in inactive_delegates | filter:search | startFrom: p.currentPage * p.pageSize | limitTo : p.pageSize">
-              <td>{{ del.rank }}</td>
-              <td>
-                <a class='delegate-link' ui-sref="account.delegate({name: del.name})">{{ del.name }}</a>
-                <br>
-                <i ng-show="del.public_data.version"> Version: {{del.public_data.version}} </i>
-                <br>
-                <i><a target="_blank" href='http://{{del.public_data.gui_data.website}}'> {{del.public_data.gui_data.website}} </a></i>
-              </td>
-              <td>
-                  <span ng-switch on='del.delegate_info.votes_for/current_xts_supply<0.0001'
-                        tooltip="{{ 'delegate.votes_obtained' | translate }}: {{ del.delegate_info.votes_for | formatVotes}}">
-            <span ng-switch-when='true'>&#60;0.01%</span>
-            <span ng-switch-default>{{ (del.delegate_info.votes_for)/current_xts_supply*100 | number:2 }}%</span>
-          </span>
-              </td>
-              <td class='hideableCol'>{{ del.delegate_info.pay_rate }}%</td>
-              <td>
-                <div class="btn-group">
-                  <button ng-click="toggleVoteUp(del.name)" class="btn btn-sm btn-link primary" tooltip="{{ 'account.toggle.approval' | translate }}">
-                    <i ng-if="accounts[del.name].approved>0" class='fa fa-thumbs-up fa-2x'></i>
-                    <i ng-if="!accounts[del.name].approved || account.approved==0" class='fa fa-thumbs-o-up fa-2x'></i>
-                    <i ng-if="accounts[del.name].approved<0" class='fa fa-thumbs-down fa-2x'></i>
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
 </div>

--- a/app/templates/delegates/delegates_list.html
+++ b/app/templates/delegates/delegates_list.html
@@ -27,16 +27,16 @@
       <table style='width:100%' class="table table-striped">
         <thead>
           <tr style="text-transform: uppercase;">
-            <th translate>th.rank</th>
-            <th translate>th.name</th>
+            <th ng-click="orderByField='rank'; reverseSort = !reverseSort" ><ng-sort-fa order-string="rank" reverse-sort="{{reverseSort}}" order-by-field="{{orderByField}}"></ng-sort-fa><span translate>th.rank</span></th>
+            <th ng-click="orderByField='name'; reverseSort = !reverseSort" ><ng-sort-fa order-string="name" reverse-sort="{{reverseSort}}" order-by-field="{{orderByField}}"></ng-sort-fa><span translate>th.name</span></th>
             <th translate>th.approval</th>
             <th translate>th.reliability</th>
-            <th translate>th.pay_rate</th>
+            <th ng-click="orderByField='delegate_info.pay_rate'; reverseSort = !reverseSort" ><ng-sort-fa order-string="delegate_info.pay_rate" reverse-sort="{{reverseSort}}" order-by-field="{{orderByField}}"></ng-sort-fa><span translate>th.pay_rate</span></th>
             <th translate>th.approve</th>
           </tr>
         </thead>
         <tbody>
-          <tr ng-repeat="del in active_delegates | filter:search">
+          <tr ng-repeat="del in active_delegates | filter:search | orderBy: [orderByField,'name']:reverseSort track by del.id">
             <td>{{ del.rank }}</td>
             <td>
               <a class='delegate-link' ui-sref="account.delegate({name: del.name})"><strong>{{ del.name }}</strong></a>
@@ -93,16 +93,16 @@
         <table class="table table-striped">
           <thead>
             <tr style="text-transform: uppercase;">
-              <th translate>th.rank</th>
-              <th translate>th.name</th>
+              <th ng-click="orderByFieldStandby='rank'; reverseSortStandby = !reverseSortStandby" ><ng-sort-fa order-string="rank" reverse-sort="{{reverseSortStandby}}" order-by-field="{{orderByFieldStandby}}"></ng-sort-fa><span translate>th.rank</span></th>
+            <th ng-click="orderByFieldStandby='name'; reverseSortStandby = !reverseSortStandby" ><ng-sort-fa order-string="name" reverse-sort="{{reverseSortStandby}}" order-by-field="{{orderByFieldStandby}}"></ng-sort-fa><span translate>th.name</span></th>
               <th translate>th.approval</th>
               <th translate>th.reliability</th>
-              <th translate>th.pay_rate</th>
+              <th ng-click="orderByFieldStandby='delegate_info.pay_rate'; reverseSortStandby = !reverseSortStandby" ><ng-sort-fa order-string="delegate_info.pay_rate" reverse-sort="{{reverseSortStandby}}" order-by-field="{{orderByFieldStandby}}"></ng-sort-fa><span translate>th.pay_rate</span></th>
               <th translate>th.approve</th>
             </tr>
           </thead>
           <tbody>
-            <tr ng-repeat="del in inactive_delegates | filter:search | startFrom: p.currentPage * p.pageSize | limitTo : p.pageSize">
+            <tr ng-repeat="del in inactive_delegates | filter:search | startFrom: p.currentPage * p.pageSize | limitTo : p.pageSize | orderBy: [orderByFieldStandby,'name']:reverseSortStandby track by del.id">
               <td>{{ del.rank }}</td>
               <td>
                 <a class='delegate-link' ui-sref="account.delegate({name: del.name})">{{ del.name }}</a>

--- a/app/templates/dialog-mail-compose.html
+++ b/app/templates/dialog-mail-compose.html
@@ -38,7 +38,7 @@
 </div>
 <div class="col-xs-3">
     <div class="pull-right">
-        <img ng-src="http://robohash.org/set_1/{{email.recipient}}?size=100x100" height="100" width="100"/>
+        <img ng-src="http://robohash.org/set_1/{{email.recipient}}?size=200x200" height="100" width="100"/>
     </div>
 </div>
 </div><!--row-->

--- a/app/templates/dialog-mail-show.html
+++ b/app/templates/dialog-mail-show.html
@@ -29,7 +29,7 @@
 </div>
 <div class="col-xs-3">
     <div class="pull-right">
-        <img ng-src="http://robohash.org/set_1/{{mail.recipient}}?size=100x100" height="100" width="100"/>
+        <img ng-src="http://robohash.org/set_1/{{mail.recipient}}?size=200x200" height="100" width="100"/>
     </div>
 </div>
 </div><!--row-->

--- a/app/templates/dialog-rename.html
+++ b/app/templates/dialog-rename.html
@@ -5,7 +5,7 @@
     <div class="modal-body">
         <div class="row">
             <div class='col-sm-4'>
-                <img style='margin:0px;padding:0px' ng-src="http://robohash.org/set_1/{{m.newname}}?size=512x512" class="img-responsive"/>
+                <img style='margin:0px;padding:0px' ng-src="http://robohash.org/set_1/{{m.newname}}?size=200x200" class="img-responsive"/>
             </div>
 
             <div class='col-sm-8'>

--- a/app/templates/dialog-transfer-confirmation.html
+++ b/app/templates/dialog-transfer-confirmation.html
@@ -4,7 +4,7 @@
 <div class="modal-body">
   <div class="row">
     <div class='col-sm-4'>
-      <img style='margin:0px;padding:0px' ng-src="http://robohash.org/set_1/{{trx.to}}?size=512x512" class="img-responsive"/>
+      <img style='margin:0px;padding:0px' ng-src="http://robohash.org/set_1/{{trx.to}}?size=200x200" class="img-responsive"/>
     </div>
     <div class='col-sm-8'>
       <table class="table table-striped table-hover">

--- a/app/templates/market/short.html
+++ b/app/templates/market/short.html
@@ -1,9 +1,16 @@
+<div ng-class="{ 'simple-mode-short-stub':!advanced, 'advanced-mode': advanced }">
+  <a ng-click="flip_advanced()" class="market-header-button">
+    <i class="fa {{advanced ? 'fa-check-square-o' : 'fa-square-o'}} fa-fw"></i>
+    <span translate>market.advanced</span>
+  </a>
+</div>
 <form ng-show="advanced" name="short_form" class="form-horizontal order-form" role="form" ng-submit="submit_short()" novalidate>
   <!--balance-->
   <div form-hgroup-value label="{{'market.balance'|translate}}" show-value="true" data-symbol="{{actual_market.quantity_symbol}} ({{account.name}})">
     <span class="clickable" ng-click="use_trade_data({collateral: account.short_balance})">
       {{account.short_balance | formatDecimal : market.base_precision}}
     </span>
+
   </div>
   <!--collateral-->
   <div form-hgroup label="{{'market.collateral'|translate}}" addon="{{actual_market.quantity_symbol}}" label-popover="{{'market.help.short_collateral' | translate:short_translation_data}}">
@@ -30,9 +37,4 @@
   <button form-hgroup-submit-btn help="{{'block.trx.fee'|translate}} {{blockchain_tx_fee}} {{blockchain_symbol}}"><span translate>market.short</span> {{actual_market.base_symbol}}</button>
 </form>
 
-<div ng-show="!advanced" class="simple-mode-short-stub">
-  <a ng-click="flip_advanced()" class="market-header-button">
-            <i class="fa {{advanced ? 'fa-check-square-o' : 'fa-square-o'}} fa-fw"></i>
-            <span translate>market.advanced</span></a>
-</div>
 

--- a/app/templates/newcontact.html
+++ b/app/templates/newcontact.html
@@ -8,7 +8,7 @@
 
     <div class="col-sm-3 m-top">
       <div class="avatar col-lg-offset-3 col-md-offset-2">
-        <img ng-src="http://robohash.org/set_1/{{account_name}}?size=150x150" height="150" width="150" ng-if="account_name"
+        <img ng-src="http://robohash.org/set_1/{{account_name}}?size=200x200" height="150" width="150" ng-if="account_name"
              tooltip="Your RoboHash is a security feature that helps you verify account names visually"/>
         <img src="img/user.png" height="150" width="150" ng-if="!account_name"/>
       </div>

--- a/app/templates/newcontactmodal.html
+++ b/app/templates/newcontactmodal.html
@@ -5,7 +5,7 @@
   <div class="row">
     <div class="col-md-2">
       <div class="avatar">
-        <img ng-src="http://robohash.org/set_1/{{account.name}}?size=100x100" height="100" width="100" ng-if="account.name"/>
+        <img ng-src="http://robohash.org/set_1/{{account.name}}?size=200x200" height="100" width="100" ng-if="account.name"/>
         <img src="img/user.png" height="100" width="100" ng-if="!account.name"/>
       </div>
     </div>

--- a/app/templates/ng-sort-template.html
+++ b/app/templates/ng-sort-template.html
@@ -1,0 +1,1 @@
+<span style="float:left;padding-right:0.5em;" class="fa fa-sort-asc" ng-if="orderByField==orderString && reverseSort=='false'"></span><span style="float:left;padding-right:0.5em;" class="fa fa-sort-desc" ng-if="orderByField==orderString && reverseSort=='true'"></span>

--- a/app/templates/to_typeahead.html
+++ b/app/templates/to_typeahead.html
@@ -1,4 +1,4 @@
 <a>
-  <img ng-src="http://robohash.org/set_1/{{match.label.name}}?size=32x32" height="32" width="32"/>
+  <img ng-src="http://robohash.org/set_1/{{match.label.name}}?size=200x200" height="32" width="32"/>
   {{match.label.name}}
 </a>

--- a/app/templates/transactions.html
+++ b/app/templates/transactions.html
@@ -36,7 +36,7 @@
                 <!--From-->
                 <span ng-if="entry.from.charAt(0) !== 'X'">
                     <span ng-if="entry.from[0] !== entry.from[0].toUpperCase()">
-                        <img ng-src="http://robohash.org/set_1/{{entry.from}}?size=72x72" height="36" width="36"/>
+                        <img ng-src="http://robohash.org/set_1/{{entry.from}}?size=200x200" height="36" width="36"/>
                         <a ui-sref="account.transactions({name: entry.from})">{{ entry.from }}</a>
                     </span>
                     <span ng-if="entry.from[0] === entry.from[0].toUpperCase()">
@@ -56,7 +56,7 @@
                 </span>
                 <span ng-if='entry.from != entry.to'>
                     <span ng-if="entry.to[0] !== entry.to[0].toUpperCase()">
-                        <img src="http://robohash.org/set_1/{{entry.to}}?size=72x72" height="36" width="36"/>
+                        <img src="http://robohash.org/set_1/{{entry.to}}?size=200x200" height="36" width="36"/>
                         <span>
                             <a ui-sref="account.transactions({name: entry.to})" ng-if="entry.to[0] != entry.to[0].toUpperCase()">{{ entry.to }}</a>
                             <span ng-if="entry.to[0] == entry.to[0].toUpperCase()">{{ entry.from }}</span>

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -9,7 +9,7 @@
 <div class="row head-bg account-page" ng-if="show_from_section">
   <div class="col-sm-2">
     <div class="avatar move-right-50px">
-      <img class="avatar-150" ng-src="http://robohash.org/set_1/{{account_from_name}}?size=150x150" height="150" width="150"/>
+      <img class="avatar-150" ng-src="http://robohash.org/set_1/{{account_from_name}}?size=200x200" height="150" width="150"/>
     </div>
     <br/>
   </div>
@@ -52,7 +52,7 @@
   <div class="col-sm-2">
     <div class="avatar move-right-50px">
       <div style='width:150px;padding:0px;margin:0px' ng-if="transfer_info.payto">
-        <img class="avatar-150" ng-src="http://robohash.org/set_1/{{transfer_info.payto}}?size=150x150" height="150" width="150"/>
+        <img class="avatar-150" ng-src="http://robohash.org/set_1/{{transfer_info.payto}}?size=200x200" height="150" width="150"/>
         <br/><br>
         <div class="avatar-150 text-center" ng-if='transfer_info.payto!=account.name'>
           <button ng-click="toggleFavoriteContact(transfer_info.payto)" class="btn btn-sm btn-link primary" tooltip="{{ 'account.toggle.favorite' | translate }}">


### PR DESCRIPTION
This should fix #559, it removes any UIA that has a name identical to a market asset.

I've added reliability to the delegates table and also made pay rate visible at all times for standby delegates. The table has plenty of unused space so I don't think this should cause any problems. I also made a function to open external links using $window.

The orderbook change is to make the plots increase in steps rather than linearly. 