### PR TITLE
New layout for market page

### DIFF
--- a/app/css/market.css
+++ b/app/css/market.css
@@ -184,7 +184,7 @@ tr.short_wall td {
 }
 
 .sell-orders-title {
-	color: #ff7f0e;
+	color: #c90808;
 }
 
 .short-orders-title {
@@ -193,6 +193,11 @@ tr.short_wall td {
 
 .margin-orders-title {
 	color: #6390bc;
+}
+
+.market-table-title {
+	padding: 0.5em 0em 0.5em 0.5em;
+	text-transform: uppercase;
 }
 
 .market-header-button {
@@ -359,4 +364,10 @@ tr.short_wall td {
 
 .search_market_div {
 	padding-right: 0;
+}
+
+.table > thead > tr > th, .ui-grid-top-panel .ui-grid-cell-contents {
+	color: #333;
+	font-size: 10px;
+	font-weight: bold;
 }

--- a/app/js/app.coffee
+++ b/app/js/app.coffee
@@ -113,4 +113,10 @@ app.config ($idleProvider, $translateProvider, $tooltipProvider, $compileProvide
     $idleProvider.idleDuration(1776)
     $idleProvider.warningDuration(60)
 
+    Highcharts.setOptions(
+                        {lang: 
+                            rangeSelectorZoom :""
+                        }
+    )
+
 

--- a/app/js/controllers/market.coffee
+++ b/app/js/controllers/market.coffee
@@ -100,6 +100,8 @@ angular.module("app").controller "MarketController", ($scope, $state, $statePara
         MarketGrid.disableMouseScroll()
 
         $scope.asks = MarketService.asks
+        console.log $scope.asks
+        # $scope.spread = MarketService.asks
         $scope.shorts = MarketService.shorts
         $scope.covers = MarketService.covers
         $scope.trades = MarketService.trades

--- a/app/js/controllers/market.coffee
+++ b/app/js/controllers/market.coffee
@@ -100,7 +100,6 @@ angular.module("app").controller "MarketController", ($scope, $state, $statePara
         MarketGrid.disableMouseScroll()
 
         $scope.asks = MarketService.asks
-        console.log $scope.asks
         # $scope.spread = MarketService.asks
         $scope.shorts = MarketService.shorts
         $scope.covers = MarketService.covers

--- a/app/js/directives/orderbookchart.coffee
+++ b/app/js/directives/orderbookchart.coffee
@@ -15,6 +15,7 @@ initChart = (scope) ->
             enabled: false
 
         legend:
+            enabled: false
             verticalAlign: "top"
 
         tooltip:
@@ -27,17 +28,18 @@ initChart = (scope) ->
 
         yAxis:
             title:
-                text: "Volume " + scope.volumeSymbol
+                text: ""
+
 
         series: [
             name: "Buy " + scope.volumeSymbol
             data: scope.bidsArray
-            color: "#2ca02c"
+            color: "#28a92e"
             lineWidth: 1
         ,
             name: "Sell " + scope.volumeSymbol
             data: scope.asksArray
-            color: "#ff7f0e"
+            color: "#c90808"
             lineWidth: 1
         ]
 
@@ -45,6 +47,8 @@ initChart = (scope) ->
             area:
                 marker:
                     enabled: false
+            series:
+                fillOpacity: 0.25
 
 addPlotLine = (chart, value) ->
     chart.xAxis[0].addPlotLine

--- a/app/js/directives/pricechart.coffee
+++ b/app/js/directives/pricechart.coffee
@@ -27,35 +27,49 @@ initChart = (scope) ->
             #color: "#f0f"
             changeDecimals: 4
             #borderColor: "#058dc7"
-            valueDecimals: (scope.volumePrecision+"").length - 1
+            valueDecimals: (scope.volumePrecision+"").length - 3
+            valueSuffix: ' ' + scope.priceSymbol
 
         scrollbar:
             enabled: false
 
         navigator:
-            enabled: true
+            enabled: false
 
         rangeSelector:
+            rangeSelectorZoom :""
             enabled: true
-            inputEnabled: true
+            inputEnabled: false
             allButtonsEnabled: true
-            #selected: 1
+            selected: 3
             buttons: [
+                type: "minute"
+                count: 30
+                text: "30m"
+            ,
                 type: "hour"
                 count: 1
-                text: "Hour"
+                text: "1h"
+            ,
+                type: "hour"
+                count: 6
+                text: "6h"
             ,
                 type: "day"
                 count: 1
-                text: "Day"
+                text: "1d"
             ,
-                type: "week"
-                count: 1
-                text: "Week"
+                type: "day"
+                count: 7
+                text: "7d"
             ,
-                type: "month"
-                count: 1
-                text: "Month"
+                type: "day"
+                count: 14
+                text: "14d"
+            ,
+                type: "day"
+                count: 30
+                text: "30d"
 #            ,
 #                type: "ytd"
 #                text: "YTD"
@@ -69,14 +83,16 @@ initChart = (scope) ->
             ]
 
         yAxis: [
-            title: { text: 'Price ' + scope.priceSymbol }
-            opposite: false
+            title: { text: '' }
+            labels: 
+                align: 'left'
+                x: 2
+            height: "65%"
         ,
-            title: { text: 'Volume ' + scope.volumeSymbol }
+            title: { text: '' }
             color: "#4572A7"
-            opposite: true
-            height: "50%"
-            top: "50%"
+            top: "70%"
+            height: "30%"            
         ]
 
         series: [
@@ -90,6 +106,8 @@ initChart = (scope) ->
             data: scope.volumedata
             yAxis: 1
             zIndex: 9
+            tooltip:
+                valueSuffix: ' ' + scope.volumeSymbol
         ]
 
 angular.module("app.directives").directive "pricechart", ->

--- a/app/js/services/market_grid.coffee
+++ b/app/js/services/market_grid.coffee
@@ -1,7 +1,7 @@
 class MarketGrid
 
     defaultParams:
-        enableColumnMenu: false
+        enableColumnMenus: false
         enableSorting: true
         useExternalSorting: false
         minRowsToShow: 16
@@ -25,12 +25,7 @@ class MarketGrid
 
     setupBidsAsksGrid: (grid, data, market, sort_direction) ->
         params =
-            columnDefs: [
-                field: "price"
-                displayName: "#{@filter('translate')('th.price')} (#{market.price_symbol})"
-                cellFilter: "formatDecimal:#{market.price_precision}:true"
-                sort: { direction: sort_direction, priority: 1 }
-            ,
+            columnDefs: [                
                 field: "quantity"
                 displayName: "#{@filter('translate')('th.quantity')} (#{market.quantity_symbol})"
                 cellFilter: "formatDecimal:#{market.quantity_precision}"
@@ -39,6 +34,11 @@ class MarketGrid
                 field: "cost"
                 displayName: "#{@filter('translate')('th.total')} (#{market.base_symbol})"
                 cellFilter: "formatDecimal:#{market.base_precision}"
+            ,
+                field: "price"
+                displayName: "#{@filter('translate')('th.price')} (#{market.price_symbol})"
+                cellFilter: "formatDecimal:#{market.price_precision}:true"
+                sort: { direction: sort_direction, priority: 1 }
             ]
             data: data
 

--- a/app/js/services/market_service.coffee
+++ b/app/js/services/market_service.coffee
@@ -550,8 +550,8 @@ class MarketService
                 l = c if c < l
 
                 oc_avg = (o + c) / 2.0
-                h = 1.10 * Math.max(o,c) if h/oc_avg > 1.25
-                l = 0.90 * Math.min(o,c) if oc_avg/l > 1.25
+                h = 1.0 * Math.max(o,c) if h/oc_avg > 1.1
+                l = 1.0 * Math.min(o,c) if oc_avg/l > 1.1
 
                 ohlc_data.push [time, o, h, l, c]
                 volume_data.push [time, t.volume / market.quantity_asset.precision]

--- a/app/js/services/wallet.coffee
+++ b/app/js/services/wallet.coffee
@@ -481,7 +481,7 @@ class Wallet
                 @location.path("/unlockwallet")
 
     open: ->
-        @rpc.request('wallet_open', ['default']).then (response) =>
+        @rpc.request('wallet_open', ['skk']).then (response) =>
           response.result
     
     get_block: (block_num)->

--- a/app/templates/market/market.html
+++ b/app/templates/market/market.html
@@ -1,237 +1,201 @@
-<div>
-<div class="col-sm-12 market-header">
-  <div class="header m-bottom">
-
-    <div class="row">
-      <h3 class="header-title col-sm-4">
-        <span tooltip="{{market.quantity_asset.description}}" tooltip-placement="right">{{market.quantity_symbol}}</span>
-        : <span tooltip="{{market.base_asset.description}}" tooltip-placement="right">{{market.base_symbol}}</span>
-        <a ng-click="flip_market()" class="market-header-button"
-            tooltip="{{'market.flip_market'|translate}}"
-            tooltip-placement="right" ng-show="account">
-            <i class="fa fa-retweet fa-fw"></i></a>
-      </h3>
-      <ul class="row market-stats stats col-sm-5">
-        <li class="stat col-sm-3">
-          <span>{{market.quantity_symbol}}&nbsp;<span translate>account.balances</span><br/><b class="value">
-           {{account.quantity_balance | formatDecimal : market.quantity_precision}}</b></span>
-        </li>
-        <li class="stat col-sm-3">
-          <span>{{market.base_symbol}}&nbsp;<span translate>account.balances</span><br/><b class="value">
-           {{account.base_balance | formatDecimal : market.base_precision}}</b></span>
-        </li>
-        <li ng-show="true || market.feed_price" class="col-sm-3 stat">
-          <span><span translate>market.feed_price</span><br/><b class="value">{{market.feed_price | formatDecimal : market.price_precision : true}}</b><br/><em>{{market.price_symbol}}</em></span>
-        </li>
-        <li ng-show="true || market.feed_price" class="col-sm-3 stat">
-          <span><span translate>asset.total_supply</span><br/><b class="value">{{asset_total_supply | formatDecimal : 2}}</b><br/><em>{{actual_market.base_symbol}}</em></span>
-        </li>
-      </ul>
-    </div>
-
-    <div class="row" ng-show="market.error.title">
-      <div class="col-sm-2">&nbsp;</div>
-      <div class="col-sm-8">
-        <div class="alert alert-danger">
-          <i class="fa fa-warning"></i>
-          &nbsp; &nbsp; <strong>{{market.error.title}}</strong> &nbsp; &nbsp; {{market.error.text}}
-        </div>
-      </div>
-      <div class="col-sm-2">&nbsp;</div>
-    </div>
-
+<div id="order_tabs" class="col-sm-4 col-xs-12" style="padding-top:10px;padding-right:0;" ng-class="{'advanced': advanced, 'shorts-available': market.shorts_available}">
+  <tabset>
+    <tab ng-repeat="t in tabs" heading="{{t.heading | translate}} {{t.route == 'market.short' ? actual_market.base_symbol : market.quantity_symbol}}" ng-click="goto_tab(t.route)" active="t.active" class="{{t.class}}">
+      <div ui-view autoscroll="false"></div>
+    </tab>
+  </tabset>
+  <div ng-if="tabs[0].active" style="padding-top:10px;">
+    <h3 class="market-table-title panel-title buy-orders-title">{{('market.open_buy_orders') | translate:'{value: market.quantity_symbol}'}}</h3>
+    <div  ng-include src="'market/open_buy.html'"></div>
+  </div>
+  <div ng-if="tabs[1].active" style="padding-top:10px;">
+    <h3 class="market-table-title panel-title sell-orders-title">{{('market.open_sell_orders') | translate:'{value: market.quantity_symbol}'}}</h3>
+    <div ng-include src="'market/open_sell.html'"></div>
+  </div>
+  <div ng-if="tabs[2].active" style="padding-top:10px;overflow-y: auto;" id="short_orders_row">
+    <h3 class="market-table-title panel-title short-orders-title">{{('market.open_short_orders') | translate:'{value: actual_market.base_symbol}'}}</h3>
+    <div ng-include src="'market/open_shorts.html'"></div>
+    <h3 class="market-table-title panel-title margin-orders-title"><span translate>market.open_margin_orders</span></h3>
+    <div ng-include src="'market/open_margin.html'"></div>
   </div>
 </div>
 
-<div class="main-content market market-content" ng-class="{'advanced': advanced, 'shorts-available': market.shorts_available}">
 
-      <!--create a stats page-->
-      <!--<ul class="row market-stats stats">-->
-        <!--<li ng-show="market.feed_price" class="stat col-sm-2">-->
-          <!--<span>{{'market.feed_price'|translate}}<br/><b class="value">{{market.feed_price | formatDecimal : market.price_precision : true}}</b><br/><em>{{market.price_symbol}}</em></span>-->
-        <!--</li>-->
-        <!--<li class="stat col-sm-2">-->
-          <!--<span>{{'market.bid_depth'|translate}}<br/><b class="value">{{market.bid_depth | formatDecimal : actual_market.quantity_precision}}</b><br/><em>{{actual_market.quantity_symbol}}</em></span>-->
-        <!--</li>-->
-        <!--<li class="stat col-sm-2">-->
-          <!--<span>{{'market.ask_depth'|translate}}<br/><b class="value">{{market.ask_depth | formatDecimal : actual_market.quantity_precision}}</b><br/><em>{{actual_market.quantity_symbol}}</em></span>-->
-        <!--</li>-->
-        <!--<li class="stat col-sm-2" ng-show="market.actual_market.collateral">-->
-        <!--<span>{{'Backing Collateral'|translate}}<br/><b class="value">{{market.actual_market.collateral | formatDecimal : actual_market.quantity_precision}}</b><br/><em>{{actual_market.quantity_symbol}}</em></span>-->
-        <!--</li>-->
-        <!--<li class="stat col-sm-2" ng-show="market.actual_market.collateral">-->
-        <!--<span>{{'Collateralization'|translate}}<br/><b class="value">{{market.actual_market.collateralization | formatDecimal : actual_market.quantity_precision}} %</b><br/><em></em></span>-->
-        <!--</li>-->
-      <!--</ul>-->
+<div>
+  <div class="col-sm-8 market-header" ng-class="{'advanced': advanced, 'shorts-available': market.shorts_available}">
+    <div class="header m-bottom">
 
-    <div class="row">
-      <div class="col-sm-12">
-        <pricechart ng-if="market.price_history.length"
-            pricedata="market.price_history"
-            volumedata="market.volume_history"
-            volume-symbol="market.inverted ? market.base_symbol : market.quantity_symbol"
-            volume-precision="market.inverted ? market.base_precision : market.quantity_precision"
-            price-symbol="market.price_symbol">
-         </pricechart>
-      </div>
-    </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <h3 class="header-title col-xs-4">
+            <span tooltip="{{market.quantity_asset.description}}" tooltip-placement="right">{{market.quantity_symbol}}</span>
+            : <span tooltip="{{market.base_asset.description}}" tooltip-placement="right">{{market.base_symbol}}</span>
+            <a ng-click="flip_market()" class="market-header-button"
+            tooltip="{{'market.flip_market'|translate}}"
+            tooltip-placement="right" ng-show="account">
+            <i class="fa fa-retweet fa-fw"></i></a>
+          </h3>
+          <ul class="row market-stats stats col-xs-8">
+            <li class="stat col-sm-3">
+              <span>{{market.quantity_symbol}}&nbsp;<span translate>account.balances</span><br/><b class="value">
+              {{account.quantity_balance | formatDecimal : market.quantity_precision}}</b></span>
+            </li>
+            <li class="stat col-sm-3">
+              <span>{{market.base_symbol}}&nbsp;<span translate>account.balances</span><br/><b class="value">
+              {{account.base_balance | formatDecimal : market.base_precision}}</b></span>
+            </li>
+            <li ng-show="true || market.feed_price" class="col-sm-3 stat">
+              <span><span translate>market.feed_price</span><br/><b class="value">{{market.feed_price | formatDecimal : market.price_precision : true}}</b><br/><em>{{market.price_symbol}}</em></span>
+            </li>
+            <li ng-show="true || market.feed_price" class="col-sm-3 stat">
+              <span><span translate>asset.total_supply</span><br/><b class="value">{{asset_total_supply | formatDecimal : 2}}</b><br/><em>{{actual_market.base_symbol}}</em></span>
+            </li>
+          </ul>
 
-    <br>
-
-    <div class="row">
-
-      <div id="order_tabs" class="col-md-5">
-        <tabset>
-          <tab ng-repeat="t in tabs" heading="{{t.heading | translate}} {{t.route == 'market.short' ? actual_market.base_symbol : market.quantity_symbol}}" ng-click="goto_tab(t.route)" active="t.active" class="{{t.class}}">
-            <div class="panel">
-              <div class="panel-body">
-                <div ui-view autoscroll="false"></div>
+          <div ng-show="market.error.title">
+            <div class="col-sm-2">&nbsp;</div>
+            <div class="col-sm-8">
+              <div class="alert alert-danger">
+                <i class="fa fa-warning"></i>
+                &nbsp; &nbsp; <strong>{{market.error.title}}</strong> &nbsp; &nbsp; {{market.error.text}}
               </div>
             </div>
-          </tab>
-        </tabset>
-      </div>
+            <div class="col-sm-2">&nbsp;</div>
+          </div>
 
-      <div class="col-md-7">
-          <orderbookchart
-              bids-array="market.orderbook_chart_data.bids_array"
-              asks-array="market.orderbook_chart_data.asks_array"
-              volume-symbol="market.quantity_symbol"
-              volume-precision="market.quantity_precision"
-              price-symbol="market.price_symbol"
-              price-precision="market.price_precision"
-              inverted-market="market.inverted"
-              feed-price="market.feed_price"
-              advanced-mode="advanced">
+        </div> 
+
+        <div class="main-content market market-content" ng-class="{'advanced': advanced, 'shorts-available': market.shorts_available}">
+
+          <!--create a stats page-->
+          <!--<ul class="row market-stats stats">-->
+          <!--<li ng-show="market.feed_price" class="stat col-sm-2">-->
+          <!--<span>{{'market.feed_price'|translate}}<br/><b class="value">{{market.feed_price | formatDecimal : market.price_precision : true}}</b><br/><em>{{market.price_symbol}}</em></span>-->
+          <!--</li>-->
+          <!--<li class="stat col-sm-2">-->
+          <!--<span>{{'market.bid_depth'|translate}}<br/><b class="value">{{market.bid_depth | formatDecimal : actual_market.quantity_precision}}</b><br/><em>{{actual_market.quantity_symbol}}</em></span>-->
+          <!--</li>-->
+          <!--<li class="stat col-sm-2">-->
+          <!--<span>{{'market.ask_depth'|translate}}<br/><b class="value">{{market.ask_depth | formatDecimal : actual_market.quantity_precision}}</b><br/><em>{{actual_market.quantity_symbol}}</em></span>-->
+          <!--</li>-->
+          <!--<li class="stat col-sm-2" ng-show="market.actual_market.collateral">-->
+          <!--<span>{{'Backing Collateral'|translate}}<br/><b class="value">{{market.actual_market.collateral | formatDecimal : actual_market.quantity_precision}}</b><br/><em>{{actual_market.quantity_symbol}}</em></span>-->
+          <!--</li>-->
+          <!--<li class="stat col-sm-2" ng-show="market.actual_market.collateral">-->
+          <!--<span>{{'Collateralization'|translate}}<br/><b class="value">{{market.actual_market.collateralization | formatDecimal : actual_market.quantity_precision}} %</b><br/><em></em></span>-->
+          <!--</li>-->
+          <!--</ul>-->
+
+          <div class="row">
+            <div class="col-md-4">
+              <h3 class="market-table-title panel-title sell-orders-title">{{'market.sell_orders'|translate:'{value: market.quantity_symbol}'}}</h3>
+              <div ui-grid="listSellGrid" class="market-grid" external-scopes="this"></div>
+              <center><h3 class="market-table-title panel-title buy-orders-title">Spread: {{ (asks[0].price - bids[0].price | number:3) + ' '+market.base_symbol}}</h3></center>
+              <div ui-grid="listBuyGrid" class="market-grid" external-scopes="this"></div>
+            </div>
+
+            <div class="col-md-8 col-sm-12" style="padding-left:0;">
+              <pricechart ng-if="market.price_history.length"
+              pricedata="market.price_history"
+              volumedata="market.volume_history"
+              volume-symbol="market.inverted ? market.base_symbol : market.quantity_symbol"
+              volume-precision="market.inverted ? market.base_precision : market.quantity_precision"
+              price-symbol="market.price_symbol">
+            </pricechart>
+
+
+            <orderbookchart
+            bids-array="market.orderbook_chart_data.bids_array"
+            asks-array="market.orderbook_chart_data.asks_array"
+            volume-symbol="market.quantity_symbol"
+            volume-precision="market.quantity_precision"
+            price-symbol="market.price_symbol"
+            price-precision="market.price_precision"
+            inverted-market="market.inverted"
+            feed-price="market.feed_price"
+            advanced-mode="advanced">
           </orderbookchart>
 
-          <!--<shortscollatchart ng-if="advanced"-->
-              <!--shortscollat-array="market.shortscollat_chart_data.array"-->
-              <!--volume-symbol="actual_market.base_symbol"-->
-              <!--volume-precision="market.base_precision"-->
-              <!--price-symbol="market.price_symbol"-->
-              <!--price-precision="market.price_precision"-->
-              <!--inverted-market="market.inverted"-->
-              <!--shorts-price="market.shorts_price">-->
-          <!--</shortscollatchart>-->
+          <div ng-if="!tabs[0].active" class="col-xs-12">
+            <h3 class="market-table-title panel-title buy-orders-title">{{('market.open_buy_orders') | translate:'{value: market.quantity_symbol}'}}</h3>
+            <div ng-include src="'market/open_buy.html'"></div>
+          </div>
+          <div ng-if="!tabs[1].active" class="col-xs-12">
+            <h3 class="market-table-title panel-title sell-orders-title">{{('market.open_sell_orders') | translate:'{value: market.quantity_symbol}'}}</h3>
+            <div ng-include src="'market/open_sell.html'"></div>
+          </div>
+          <div ng-if="!tabs[2].active" id="short_orders_row" ng-show="advanced">
+            <div class="col-xs-12">
+              <h3 class="market-table-title panel-title short-orders-title">{{('market.open_short_orders') | translate:'{value: actual_market.base_symbol}'}}</h3>
+              <div ng-include src="'market/open_shorts.html'"></div>
+            </div>
+            <div class="col-xs-12">
+              <h3 class="market-table-title panel-title margin-orders-title"><span translate>market.open_margin_orders</span></h3>
+              <div ng-include src="'market/open_margin.html'"></div>
+            </div>
+          </div>
+        </div>
+
+        <!--<shortscollatchart ng-if="advanced"-->
+        <!--shortscollat-array="market.shortscollat_chart_data.array"-->
+        <!--volume-symbol="actual_market.base_symbol"-->
+        <!--volume-precision="market.base_precision"-->
+        <!--price-symbol="market.price_symbol"-->
+        <!--price-precision="market.price_precision"-->
+        <!--inverted-market="market.inverted"-->
+        <!--shorts-price="market.shorts_price">-->
+        <!--</shortscollatchart>-->
 
       </div>
-    </div>
 
-    <br>
 
-    <div class="row">
-        <div class="panel col-xs-12 col-sm-6">
-            <div class="panel-heading">
-                <h3 class="panel-title buy-orders-title">{{('market.open_buy_orders') | translate:'{value: market.quantity_symbol}'}}</h3>
-            </div>
-            <div class="panel-body">
-                <div ng-include src="'market/open_buy.html'"></div>
-            </div>
-        </div>
-        <div class="panel col-xs-12 col-sm-6">
-            <div class="panel-heading">
-                <h3 class="panel-title sell-orders-title">{{('market.open_sell_orders') | translate:'{value: market.quantity_symbol}'}}</h3>
-            </div>
-            <div class="panel-body">
-                <div ng-include src="'market/open_sell.html'"></div>
-            </div>
-        </div>
-    </div>
-    <div id="short_orders_row" class="row" ng-show="advanced">
-        <div class="panel col-xs-12 col-sm-6">
-            <div class="panel-heading">
-                <h3 class="panel-title short-orders-title">{{('market.open_short_orders') | translate:'{value: actual_market.base_symbol}'}}</h3>
-            </div>
-            <div class="panel-body">
-                <div ng-include src="'market/open_shorts.html'"></div>
-            </div>
-        </div>
-        <div class="panel col-xs-12 col-sm-6">
-            <div class="panel-heading">
-                <h3 class="panel-title margin-orders-title"><span translate>market.open_margin_orders</span></h3>
-            </div>
-            <div class="panel-body">
-                <div ng-include src="'market/open_margin.html'"></div>
-            </div>
-        </div>
-    </div>
 
-    <div class="row">
-      <div class="panel col-md-6">
-        <div class="panel-heading">
-          <h3 class="panel-title buy-orders-title">{{'market.buy_orders'|translate:'{value: market.quantity_symbol}'}}</h3>
-        </div>
-        <div class="panel-body">
-          <div ui-grid="listBuyGrid" class="market-grid" external-scopes="this"></div>
-        </div>
-      </div>
-      <div class="panel col-md-6">
-        <div class="panel-heading">
-          <h3 class="panel-title sell-orders-title">{{'market.sell_orders'|translate:'{value: market.quantity_symbol}'}}</h3>
-        </div>
-        <div class="panel-body">
-          <div ui-grid="listSellGrid" class="market-grid" external-scopes="this"></div>
-        </div>
-      </div>
-    </div>
 
-    <div class="row" ng-show="market.shorts_available && advanced">
-      <div class="panel" ng-class="'col-md-6'">
-        <div class="panel-heading">
-          <h3 class="panel-title short-orders-title">{{
+
+
+
+      <div class="row" ng-show="market.shorts_available && advanced">
+        <div class="" ng-class="'col-md-6'">
+          <h3 class="market-table-title panel-title short-orders-title">{{
             (market.inverted ?
-              ('market.margin_orders'|translate)
+            ('market.short_orders'|translate:'{value: actual_market.base_symbol}')
             :
-              ('market.short_orders'|translate:'{value: actual_market.base_symbol}')
-            )
-           }}
-           <span ng-show="market.inverted" class="help-popover" popover="{{'market.margin_orders_explain'|translate}}" popover-trigger="mouseenter"><i class="fa fa-question-circle"></i></span>
-          </h3>
-        </div>
-        <div class="panel-body">
-          <div ui-grid="listShortsMarginsLeftGrid" class="market-grid" external-scopes="this" ui-grid-auto-resize></div>
-        </div>
-      </div>
-      <div class="panel" ng-class="'col-md-6'">
-        <div class="panel-heading">
-          <h3 class="panel-title short-orders-title">{{
-            (market.inverted ?
-              ('market.short_orders'|translate:'{value: actual_market.base_symbol}')
-            :
-              ('market.margin_orders'|translate)
+            ('market.margin_orders'|translate)
             )
           }}
           <span ng-show="!market.inverted" class="help-popover" popover="{{'market.margin_orders_explain'|translate}}" popover-trigger="mouseenter"><i class="fa fa-question-circle"></i></span>
-          </h3>
-        </div>
-        <div class="panel-body">
-          <div ui-grid="listShortsMarginsRightGrid" class="market-grid" external-scopes="this" ui-grid-auto-resize></div>
-        </div>
+        </h3>
+        <div ui-grid="listShortsMarginsRightGrid" class="market-grid" external-scopes="this" ui-grid-auto-resize></div>
       </div>
+      <div class="" ng-class="'col-md-6'">
+        <h3 class="market-table-title panel-title short-orders-title">{{
+          (market.inverted ?
+          ('market.margin_orders'|translate)
+          :
+          ('market.short_orders'|translate:'{value: actual_market.base_symbol}')
+          )
+        }}
+        <span ng-show="market.inverted" class="help-popover" popover="{{'market.margin_orders_explain'|translate}}" popover-trigger="mouseenter"><i class="fa fa-question-circle"></i></span>
+      </h3>
+      <div ui-grid="listShortsMarginsLeftGrid" class="market-grid" external-scopes="this" ui-grid-auto-resize></div>
     </div>
+    
+  </div>
 
-    <div class="row">
-      <div class="col-sm-6" ng-show="advanced">
-        <div class="panel ">
-          <div class="panel-heading">
-            <h3 class="panel-title" translate>market.blockchain_orders_history</h3>
-          </div>
-          <div class="panel-body">
-            <div ui-grid="listBlockchainOrders" class="market-grid" external-scopes="this"></div>
-          </div>
-        </div>
-      </div>
-      <div class="col-sm-6">
-        <div class="panel ">
-          <div class="panel-heading">
-            <h3 class="panel-title" translate>market.account_orders_history</h3>
-          </div>
-          <div class="panel-body">
-            <div ui-grid="listAccountOrders" class="market-grid" external-scopes="this"></div>
-          </div>
-        </div>
+  <div class="row">
+    <div class="col-sm-6" ng-show="advanced">
+      <div class=" ">
+        <h3 class="market-table-title panel-title" translate>market.blockchain_orders_history</h3>
+        <div ui-grid="listBlockchainOrders" class="market-grid" external-scopes="this"></div>
       </div>
     </div>
+    <div class="col-sm-6">
+      <div class="">
+        <h3 class="market-table-title panel-title" translate>market.account_orders_history</h3>
+        <div ui-grid="listAccountOrders" class="market-grid" external-scopes="this"></div>
+      </div>
+    </div>
+  </div>
+</div>
 </div>
 </div>


### PR DESCRIPTION
I've made an attempt at revamping the market layout slightly. Some comments:

- I wanted to make the left div fixed position so it doesn't scroll with the rest of the page but it causes issues when there are many open orders
- I've made ui-grid headers black and bold but slightly smaller, this is a global change but I prefer it like that, the light grey was often hard to see
-The "Sell orders" table should ideally be sorted the other way, meaning it should increase from the bottom so that it nicely matches the buy orders table. I'm not sure how to do this with ui-grid..

Please check it out and let me know what you think