### PR TITLE
backslash to forwardslash in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Edit htdocs parameter in config.json  `AppData/Roaming/BitShares` to point to th
 Start another shell, navigate to `/bin/programs/client/RelWithDebInfo` directory, and start
 the BitShares client:
 
-    $ .\bitshares_client --server \
+    $ ./bitshares_client --server \
         --rpcuser=test --rpcpassword=test \
         --httpdendpoint=127.0.0.1:5000
 (You could also achieve this by changing these parameters in your config file.)


### PR DESCRIPTION
I am not an c expert, but for me on my mac ` .\bitshares_client ` doesn't work and ` ./bitshares_client ` does.